### PR TITLE
fix: use github https url

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "good-enough-parser",
   "description": "Parse and query computer programs source code",
   "version": "1.1.17",
-  "repository": "git@github.com:zharinov/good-enough-parser.git",
+  "repository": "https://github.com/zharinov/good-enough-parser.git",
   "author": "Sergei Zharinov",
   "contributors": [
     "Jason Kuhrt"


### PR DESCRIPTION
the other url isn't usable by renovate to fetch changelogs